### PR TITLE
[BOJ] 1629 곱셈 (오답)

### DIFF
--- a/BOJ/1629/4923.ipynb
+++ b/BOJ/1629/4923.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Python / [1629](https://www.acmicpc.net/problem/1629) / BOJ / 재귀, recursion\n",
+    "\n",
+    "- 문제: 자연수 A를 B번 곱한 수를 알고 싶다. 단 구하려는 수가 매우 커질 수 있으므로 이를 C로 나눈 나머지를 구하는 프로그램을 작성하시오.\n",
+    "- 입력: 첫째 줄에 A, B, C가 빈 칸을 사이에 두고 순서대로 주어진다. A, B, C는 모두 2,147,483,647 이하의 자연수이다.\n",
+    "- 출력: 첫째 줄에 A를 B번 곱한 수를 C로 나눈 나머지를 출력한다."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A를 B번 곱한다 == A ** B\n",
+    "A를 B번 곱한 수를 C로 나눈 나머지를 구한다 == A ** B % C\n",
+    "\n",
+    "- 이론적으로 제곱은 곱셈의 연속\n",
+    "- 나머지는 나누는 수 C 보다 클 수 없다. (A, B, C 모두 범위가 동일하므로 범위를 좁힐 수 는 없음)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "파이썬에서 `//` 는 몫을 구하는 연산자고 `%` 는 나머지를 구하는 연산자다.\n",
+    "\n",
+    "$q$ 가 quotient 이므로 몫이고 $r$이 remainder 이므로 나머지일 때 $A$는 아래 식으로 표현할 수 있다.\n",
+    "\n",
+    "$$A = C * q_{A} + r_{A} = A//C + A\\%C $$\n",
+    "\n",
+    "몫의 나머지는 0이므로 $(A//C)\\%C = 0$ 이고 $A^{B}$ 는 $A$를 $B$번 곱한 것이니  $A^{B}$ 는 아래와 같다.\n",
+    "\n",
+    "$$A^{B} = (A//C)^{B} + (A\\%C)^{B} + ... $$\n",
+    "\n",
+    "이를 나머지연산하면 아래와 같은 식으로 변형된다.\n",
+    "\n",
+    "$$A^{B}\\%C = ((A//C)^{B})\\%C + ((A\\%C)^{B})\\%C + ... $$ \n",
+    "\n",
+    "이 때 $(A//C)^{B}\\%C =0$ 이므로 파생되는 항이었던 $...$ 는 지워지고 $A^{B}\\%C = ((A\\%C)^{B})\\%C$ 가 된다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 위 증명을 이용하여 아래와 같은 코드를 작성할 수 있다.\n",
+    "\n",
+    "A, B, C = map(int, input().split())\n",
+    "answer = ((A % C) ** B) % C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 그런데 틀렸다.\n",
+    "\n",
+    "<img width=\"1318\" alt=\"image\" src=\"https://user-images.githubusercontent.com/60145951/179163488-092d2f98-f73a-4019-baa0-1df8f7188d89.png\">\n",
+    "\n",
+    "input을 한번만 받기 때문에 stdin을 안써서 틀린건 아닌 것 같다. 연산할 값의 범위를 더 좁혀야겠는데 어떻게 하지?\n",
+    "\n",
+    "- 곱할때마다 끝자리수가 반복된다는 곱셈의 특성을 적용할 방법을 찾고 싶다.\n",
+    "- 재귀적으로 풀어야 할 것 같은데 맞을까? -> [백준 질문 중 참고할만한 질문을 찾았다.](https://www.acmicpc.net/board/view/86998)\n",
+    "\n",
+    "우선\n",
+    "\n",
+    "> 파이썬에서는 수가 커지면 곱셈에 걸리는 시간도 그만큼 오래 걸립니다.  \n",
+    "> CPU 레지스터를 사용하여 곱셈을 수행하는 C나 C++의 경우에는 표현 가능 범위 내에서는 일반적으로 곱셈의 시간이 항상 같지만,   \n",
+    "> 파이썬은 큰 수의 곱셈을 계산하기 위해서 그를 2진수 자릿수 단위별로 끊어서 저장하고 빠른 곱셈 알고리즘을 통해 연산을 직접 구현합니다.   \n",
+    "> 그래서 자릿수가 늘어나면 그에 비례하는 것 이상으로 많은 시간이 걸리게 됩니다.  \n",
+    "\n",
+    "그렇다고 하니 재귀적으로 푸는것이 낫고, $B$를 최대한 줄일 방법을 찾아야겠다.\n",
+    "\n",
+    "\n",
+    "#### 힌트: 상황을 나누는 방법 ([경준님 풀이](https://github.com/hufslion10th/HUFSALGO/pull/11))\n",
+    "- 상황을 줄이는 방법: 제곱하는 값 ($B$)이 짝수일 때와 홀수일 때를 구분한다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A, B, C = map(int, input().split())\n",
+    "\n",
+    "def powering (A, B, C):\n",
+    "    # 탈출조건\n",
+    "    if B == 1:\n",
+    "        return A % C\n",
+    "    elif B == 2:\n",
+    "        return (A ** A) % C\n",
+    "    else:\n",
+    "        if B % 2 == 0:  # 짝수인 경우\n",
+    "            return powering((A, B // 2, C) ** 2 * A ) % C\n",
+    "        else:\n",
+    "            return powering((A, B // 2, C) ** 2 * A ) % C\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## 로직 개요

Python / [1629](https://www.acmicpc.net/problem/1629) / BOJ / 재귀, 모듈러

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/60145951/179509951-7dbd753a-87ab-4a22-81f3-701363077625.png">

위 로직으로 `answer = ((A % C) ** B) % C` 를 짰는데 시간초과가 발생했다.
C의 값을 줄여보려고 한 시도인데, B도 곱셈법칙을 이용해 줄여볼 수 있을 것 같다.


### 결과

- [ ] 왜 홀, 짝을 나눠 구분하는지는 잘 모르겠음
- [ ] 곱셈에서 특정 곱마다 끝자리수가 달라지고, 나머지가 반복된다는 원리를 이용하고 싶은데 아리송함.
> B//2 를 했을때 '시간초과'가 아니라 '틀렸음'이 뜨는 걸 보니 시간초과 해결을 위해서는 이 방향을 파는게 맞는듯 하다.


### 그 외
정답 뜨면 리뷰요청 예정 (잠깐 close)